### PR TITLE
Update resource_read.html fix missing data dictionary fields

### DIFF
--- a/ckanext/dcatapit/templates/package/resource_read.html
+++ b/ckanext/dcatapit/templates/package/resource_read.html
@@ -30,35 +30,6 @@
               </tr>
             </tbody>
           </table>
-          
-          
-          <h2>{{ _('Additional Information') }}</h2>
-          <table class="table table-striped table-bordered table-condensed" data-module="table-toggle-more">
-            <thead>
-              <tr>
-                <th scope="col">{{ _('Field') }}</th>
-                <th scope="col">{{ _('Value') }}</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th scope="row">{{ _('Last updated') }}</th>
-                <td>{{ h.render_datetime(res.last_modified) or h.render_datetime(res.revision_timestamp) or h.render_datetime(res.created) or _('unknown') }}</td>
-              </tr>
-              <tr>
-                <th scope="row">{{ _('Created') }}</th>
-                <td>{{ h.render_datetime(res.created) or _('unknown') }}</td>
-              </tr>
-              <tr>
-                <th scope="row">{{ _('Format') }}</th>
-                <td>{{ res.mimetype_inner or res.mimetype or res.format or _('unknown') }}</td>
-              </tr>
-              {% for key, value in h.format_resource_items(res.items()) %}
-                <tr class="toggle-more"><th scope="row">{{ key }}</th><td>{{ value }}</td></tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div>
+        </div> 
+        {{ super() }}
         {% endblock %}
-
-


### PR DESCRIPTION
This fix prevents dcatapit from hiding the data dictionary fields, included with ckanext-datstore.